### PR TITLE
[fix] webpack-route-manifest configuration for routes

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -6,8 +6,8 @@ module.exports = {
       webpackConfig.plugins.push(
         new RouteManifest({
           routes(str) {
-            let out = str.replace('./src/pages', '').toLowerCase()
-            if (out === '/home') return '/'
+            let out = str.replace('pages', '').toLowerCase()
+            if (out === '/home') out = '/'
             return out
           },
           filename: 'rmanifest.json',


### PR DESCRIPTION
@ryands17 

I've fixed it. It was due to the webpack route manifest configuration.
I understand it's not so easy to debug while integrating Quicklink SPA feature.
We are working on it now.